### PR TITLE
Fix for issue 3071: Villager profession in trade screen

### DIFF
--- a/Common/src/main/java/com/natamus/villagernames/events/VillagerEvent.java
+++ b/Common/src/main/java/com/natamus/villagernames/events/VillagerEvent.java
@@ -77,7 +77,7 @@ public class VillagerEvent {
 		Villager villager = (Villager)entity;
 		VillagerData d = villager.getVillagerData();
 
-		String rawProfession = d.profession().value().toString();
+		String rawProfession = d.profession().getRegisteredName();
 		if (rawProfession.equals("none") || rawProfession.equals("nitwit")) {
 			return InteractionResult.PASS;
 		}


### PR DESCRIPTION
Updated VillagerEvent.InteractionResult() method as described in my comment here: https://github.com/Serilum/.issue-tracker/issues/3071#issuecomment-2833698673

Appears to work when testing on Fabric; did not test on Forge or Neoforge.